### PR TITLE
feat: Make the network button looks like Gnome

### DIFF
--- a/package/contents/ui/components/NetworkBtn.qml
+++ b/package/contents/ui/components/NetworkBtn.qml
@@ -2,21 +2,17 @@ import QtQml 2.15
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
 
-import org.kde.plasma.core as PlasmaCore
-
+import org.kde.plasma.components as PlasmaComponents
 import org.kde.plasma.networkmanagement as PlasmaNM
 import org.kde.kirigami as Kirigami
 
-
-
 import "../lib" as Lib
-import "../js/funcs.js" as Funcs
 
+Lib.Card {
 
-Lib.CardButton {
-
-    // NETWORK
-    property var network: network
+    id: networkBtn
+    property bool isLongButton: false
+    clip: true
 
     readonly property bool administrativelyEnabled:
                 !PlasmaNM.Configuration.airplaneModeEnabled
@@ -49,15 +45,191 @@ Lib.CardButton {
 
     Layout.fillWidth: true
     Layout.fillHeight: true
-    heading: isLongButton ? (isWifi ? i18n("Wi-Fi") : isAirplane ? i18n("Airplane mode") : i18n("Network")) : ""
-    
-    title: Funcs.getNetworkConnectionName()
 
-    Lib.Icon {
+    // Long button layout (with toggle and arrow)
+    RowLayout {
+        id: longLayout
         anchors.fill: parent
-        source: network.activeConnectionIcon
-        selected: (network.networkStatus.activeConnections != "") || isAirplane 
+        property bool small: width < root.fullRepWidth/3
+        anchors.margins: small ? root.smallSpacing : root.mediumSpacing
+        spacing: small ? 0 : root.smallSpacing
+        visible: isLongButton
+
+        Item {
+            id: iconLong
+            Layout.preferredHeight: longLayout.small ? longLayout.height/2 : longLayout.height * 0.6
+            Layout.preferredWidth: Layout.preferredHeight
+            Layout.alignment: Qt.AlignVCenter | Qt.AlignLeft
+
+            Kirigami.Icon {
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.left: parent.left
+                width: parent.width
+                height: parent.height
+                source: network.activeConnectionIcon
+                color: Kirigami.Theme.textColor
+            }
+        }
+
+        Column {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            spacing: 0
+
+            PlasmaComponents.Label {
+                id: heading
+                width: parent.width
+                height: parent.height / 2
+
+                font.pixelSize: root.mediumFontSize
+                font.weight: Font.Bold
+                elide: Text.ElideRight
+                visible: !longLayout.small
+                text: isWifi ? i18n("Wi-Fi") : isAirplane ? i18n("Airplane mode") : i18n("Network")
+                horizontalAlignment: Qt.AlignLeft
+                verticalAlignment: Qt.AlignBottom
+            }
+
+            PlasmaComponents.Label {
+                id: titleLong
+                width: parent.width
+                height: parent.height / 2
+                leftPadding: (longLayout.small || !heading.visible) ? root.smallSpacing : 1
+                font.pixelSize: (longLayout.small || heading.visible) ? root.smallFontSize+0.5 : root.mediumFontSize
+                font.weight: (longLayout.small || !heading.visible) ? Font.Bold : Font.Normal
+                horizontalAlignment: longLayout.small ? Qt.AlignHCenter : Qt.AlignLeft
+                verticalAlignment: !heading.visible ? Qt.AlignVCenter : Qt.AlignTop
+                wrapMode: Text.WordWrap
+                elide: Text.ElideRight
+                text: network.networkStatus.activeConnections ? i18n("Connected") : isAirplane ? i18n("On") : i18n("Disconnected")
+            }
+        }
+
+        Rectangle {
+            Layout.fillHeight: true
+            Layout.preferredWidth: 1
+            color: Kirigami.Theme.textColor
+            opacity: 0.2
+            visible: !longLayout.small
+        }
+
+        Item {
+            Layout.preferredWidth: networkBtn.height * 0.3
+            Layout.fillHeight: true
+            visible: !longLayout.small
+
+            Rectangle {
+                anchors.fill: parent
+                color: Kirigami.Theme.highlightColor
+                opacity: arrowArea.containsMouse ? 0.2 : 0
+                radius: 4
+
+                Behavior on opacity {
+                    NumberAnimation { duration: 150 }
+                }
+            }
+
+            Kirigami.Icon {
+                anchors.centerIn: parent
+                width: Math.min(parent.width, parent.height) * 0.4
+                height: width
+                source: "go-next"
+                color: Kirigami.Theme.textColor
+            }
+
+            MouseArea {
+                id: arrowArea
+                anchors.fill: parent
+                hoverEnabled: true
+                enabled: !root.editingLayout
+
+                onClicked: {
+                    fullRep.togglePage(fullRep.defaultInitialWidth, 400, networkPage)
+                }
+            }
+        }
     }
-    onClicked: fullRep.togglePage(fullRep.defaultInitialWidth, 400, networkPage);
-    
+
+    // Short button layout (icon with circle background on top, text below, opens submenu)
+    GridLayout {
+        id: shortLayout
+        anchors.fill: parent
+        property bool small: width < root.fullRepWidth/3
+        anchors.margins: shortLayout.small ? root.smallSpacing : root.largeSpacing
+        rows: 2
+        columns: shortLayout.small ? 1 : 2
+        columnSpacing: shortLayout.small ? 0 : 10*root.scale
+        rowSpacing: 0
+        visible: !isLongButton
+
+        Item {
+            id: iconShort
+            Layout.preferredHeight: shortLayout.small ? shortLayout.height/1.5 : shortLayout.height - root.largeSpacing
+            Layout.preferredWidth: Layout.preferredHeight
+            Layout.alignment: Qt.AlignVCenter | Qt.AlignHCenter
+            Layout.rowSpan: 2
+
+            Lib.Icon {
+                anchors.fill: parent
+                source: network.activeConnectionIcon
+                selected: (network.networkStatus.activeConnections != "") || isAirplane 
+            }
+        }
+
+        PlasmaComponents.Label {
+            id: titleShort
+            Layout.fillHeight: true
+            Layout.fillWidth: true
+            Layout.margins: shortLayout.small ? root.smallSpacing : 1
+            Layout.rowSpan: 2
+            font.pixelSize: shortLayout.small ? root.smallFontSize+0.5 : root.mediumFontSize
+            font.weight: Font.Bold
+            horizontalAlignment: shortLayout.small ? Qt.AlignHCenter : Qt.AlignLeft
+            verticalAlignment: Qt.AlignVCenter
+            wrapMode: Text.WordWrap
+            elide: Text.ElideRight
+            visible: text
+            text: network.networkStatus.activeConnections ? i18n("Connected") : isAirplane ? i18n("On") : i18n("Disconnected")
+        }
+    }
+
+    Rectangle {
+        anchors.fill: parent
+        color: Kirigami.Theme.highlightColor
+        opacity: (isWifi || isAirplane || isWired) ? 0.5 : (toggleArea.containsMouse ? 0.15 : 0)
+        radius: networkBtn.cornerRadius
+        z: -1
+        visible: isLongButton
+
+        Behavior on opacity {
+            NumberAnimation { duration: 150 }
+        }
+    }
+
+    MouseArea {
+        id: toggleArea
+        anchors.fill: parent
+        anchors.rightMargin: (isLongButton && !longLayout.small) ? networkBtn.height * 0.3 + root.smallSpacing + 1 : 0
+        hoverEnabled: true
+        enabled: !root.editingLayout
+
+        onClicked: {
+            if (isLongButton) {
+                // Long button: Toggle network on/off based on available device type
+                if (wifiCheckVisible) {
+                    // Toggle WiFi
+                    network.handler.enableWireless(!network.enabledConnections.wirelessEnabled)
+                } else if (airplaneCheckVisible) {
+                    // Toggle airplane mode
+                    PlasmaNM.Configuration.airplaneModeEnabled = !PlasmaNM.Configuration.airplaneModeEnabled
+                } else if (wiredCheckVisible) {
+                    // Toggle wired/WWAN
+                    network.handler.enableWwan(!network.enabledConnections.wwanEnabled)
+                }
+            } else {
+                // Short button: Open network page
+                fullRep.togglePage(fullRep.defaultInitialWidth, 400, networkPage)
+            }
+        }
+    }
 }

--- a/package/contents/ui/components/NetworkBtn.qml
+++ b/package/contents/ui/components/NetworkBtn.qml
@@ -1,6 +1,7 @@
 import QtQml 2.15
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
+import Qt5Compat.GraphicalEffects
 
 import org.kde.plasma.components as PlasmaComponents
 import org.kde.plasma.networkmanagement as PlasmaNM
@@ -14,120 +15,183 @@ Lib.Card {
     property bool isLongButton: false
     clip: true
 
-    readonly property bool administrativelyEnabled:
-                !PlasmaNM.Configuration.airplaneModeEnabled
-                && network.availableDevices.wirelessDeviceAvailable
-                && network.enabledConnections.wirelessHwEnabled
+    // Device availability checks
+    readonly property bool hasWirelessDevice: network.availableDevices.wirelessDeviceAvailable
+    readonly property bool hasModemDevice: network.availableDevices.modemDeviceAvailable
+    readonly property bool isAirplaneModeOn: PlasmaNM.Configuration.airplaneModeEnabled
 
-    readonly property bool administrativelyWiredEnabled:
-                !PlasmaNM.Configuration.airplaneModeEnabled
-                && network.availableDevices.modemDeviceAvailable
-                && network.enabledConnections.wwanHwEnabled
+    // Administrative enablement checks
+    readonly property bool administrativelyEnabled: !isAirplaneModeOn && hasWirelessDevice && network.enabledConnections.wirelessHwEnabled
+    readonly property bool administrativelyWiredEnabled: !isAirplaneModeOn && hasModemDevice && network.enabledConnections.wwanHwEnabled
 
+    // Connection state checks
     readonly property bool wifiCheckChecked: administrativelyEnabled && network.enabledConnections.wirelessEnabled
-    readonly property bool wifiCheckVisible: network.availableDevices.wirelessDeviceAvailable
+    readonly property bool wifiCheckVisible: hasWirelessDevice
 
-    readonly property bool airplaneCheckchecked: PlasmaNM.Configuration.airplaneModeEnabled
-    readonly property bool airplaneCheckVisible: network.availableDevices.modemDeviceAvailable || network.availableDevices.wirelessDeviceAvailable
+    readonly property bool airplaneCheckChecked: isAirplaneModeOn
+    readonly property bool airplaneCheckVisible: hasModemDevice || hasWirelessDevice
 
-    readonly property bool wiredCheckchecked: administrativelyWiredEnabled && network.enabledConnections.wwanEnabled
-    readonly property bool wiredCheckVisible: network.availableDevices.modemDeviceAvailable
+    readonly property bool wiredCheckChecked: administrativelyWiredEnabled && network.enabledConnections.wwanEnabled
+    readonly property bool wiredCheckVisible: hasModemDevice
 
-    readonly property var isWifi: wifiCheckChecked && wifiCheckVisible
-    readonly property var isAirplane: airplaneCheckchecked && airplaneCheckVisible
-    readonly property var isWired: wiredCheckchecked && wiredCheckVisible
+    // Computed state for active connection types
+    readonly property bool isWifi: wifiCheckChecked && wifiCheckVisible
+    readonly property bool isAirplane: airplaneCheckChecked && airplaneCheckVisible
+    readonly property bool isWired: wiredCheckChecked && wiredCheckVisible
+
+    // Helper functions and computed properties
+    function getConnectionStatusText() {
+        if (network.networkStatus.activeConnections) {
+            return i18n("Connected")
+        } else if (isAirplane) {
+            return i18n("On")
+        } else {
+            return i18n("Disconnected")
+        }
+    }
+
+    function getConnectionTypeText() {
+        if (isWifi) return i18n("Wi-Fi")
+        if (isAirplane) return i18n("Airplane mode")
+        return i18n("Network")
+    }
+
+    // Layout size helpers
+    readonly property bool isSmallLayout: width < root.fullRepWidth/3
+    readonly property bool shouldShowExtendedUI: !isSmallLayout
+
+    // Font size helpers
+    readonly property int primaryFontSize: isSmallLayout ? root.smallFontSize + 0.5 : root.mediumFontSize
+    readonly property int secondaryFontSize: shouldShowExtendedUI ? root.smallFontSize + 0.5 : root.mediumFontSize
 
     Network {
         id: network
     }
 
-    visible: true
-
     Layout.fillWidth: true
     Layout.fillHeight: true
 
-    // Long button layout (with toggle and arrow)
-    RowLayout {
-        id: longLayout
+    // Unified background for long button
+    Rectangle {
+        id: unifiedBackground
         anchors.fill: parent
-        property bool small: width < root.fullRepWidth/3
-        anchors.margins: small ? root.smallSpacing : root.mediumSpacing
-        spacing: small ? 0 : root.smallSpacing
+        color: Kirigami.Theme.highlightColor
+        opacity: (isWifi || isAirplane || isWired) ? 0.5 : 0
+        radius: networkBtn.cornerRadius
         visible: isLongButton
 
-        Item {
-            id: iconLong
-            Layout.preferredHeight: longLayout.small ? longLayout.height/2 : longLayout.height * 0.6
-            Layout.preferredWidth: Layout.preferredHeight
-            Layout.alignment: Qt.AlignVCenter | Qt.AlignLeft
-
-            Kirigami.Icon {
-                anchors.verticalCenter: parent.verticalCenter
-                anchors.left: parent.left
-                width: parent.width
-                height: parent.height
-                source: network.activeConnectionIcon
-                color: Kirigami.Theme.textColor
-            }
+        Behavior on opacity {
+            NumberAnimation { duration: 150 }
         }
 
-        Column {
-            Layout.fillWidth: true
+        // Long button layout (unified button with divider)
+        RowLayout {
+            id: longLayout
+            anchors.fill: parent
+            spacing: isSmallLayout ? 0 : root.smallSpacing / 2
+            layer.enabled: true
+            layer.effect: OpacityMask {
+                maskSource: Rectangle {
+                    width: longLayout.width
+                    height: longLayout.height
+                    radius: networkBtn.cornerRadius
+                }
+            }
+
+        // Left side (toggle)
+        RowLayout {
             Layout.fillHeight: true
-            spacing: 0
+            Layout.fillWidth: true
+            spacing: isSmallLayout ? 0 : root.smallSpacing / 2
 
-            PlasmaComponents.Label {
-                id: heading
-                width: parent.width
-                height: parent.height / 2
+            Item {
+                id: iconLong
+                Layout.preferredHeight: isSmallLayout ? longLayout.height/2 : longLayout.height * 0.6
+                Layout.preferredWidth: Layout.preferredHeight
+                Layout.alignment: Qt.AlignVCenter | Qt.AlignLeft
 
-                font.pixelSize: root.mediumFontSize
-                font.weight: Font.Bold
-                elide: Text.ElideRight
-                visible: !longLayout.small
-                text: isWifi ? i18n("Wi-Fi") : isAirplane ? i18n("Airplane mode") : i18n("Network")
-                horizontalAlignment: Qt.AlignLeft
-                verticalAlignment: Qt.AlignBottom
+                Kirigami.Icon {
+                    anchors.verticalCenter: parent.verticalCenter
+                    anchors.left: parent.left
+                    width: parent.width
+                    height: parent.height
+                    source: network.activeConnectionIcon
+                    color: Kirigami.Theme.textColor
+                }
             }
 
-            PlasmaComponents.Label {
-                id: titleLong
-                width: parent.width
-                height: parent.height / 2
-                leftPadding: (longLayout.small || !heading.visible) ? root.smallSpacing : 1
-                font.pixelSize: (longLayout.small || heading.visible) ? root.smallFontSize+0.5 : root.mediumFontSize
-                font.weight: (longLayout.small || !heading.visible) ? Font.Bold : Font.Normal
-                horizontalAlignment: longLayout.small ? Qt.AlignHCenter : Qt.AlignLeft
-                verticalAlignment: !heading.visible ? Qt.AlignVCenter : Qt.AlignTop
-                wrapMode: Text.WordWrap
-                elide: Text.ElideRight
-                text: network.networkStatus.activeConnections ? i18n("Connected") : isAirplane ? i18n("On") : i18n("Disconnected")
+            Column {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                spacing: 0
+
+                PlasmaComponents.Label {
+                    id: heading
+                    width: parent.width
+                    height: parent.height / 2
+
+                    font.pixelSize: root.mediumFontSize
+                    font.weight: Font.Bold
+                    elide: Text.ElideRight
+                    visible: shouldShowExtendedUI
+                    text: getConnectionTypeText()
+                    horizontalAlignment: Qt.AlignLeft
+                    verticalAlignment: Qt.AlignBottom
+                }
+
+                PlasmaComponents.Label {
+                    id: titleLong
+                    width: parent.width
+                    height: parent.height / 2
+                    leftPadding: (isSmallLayout || !heading.visible) ? root.smallSpacing : 1
+                    font.pixelSize: secondaryFontSize
+                    font.weight: (isSmallLayout || !heading.visible) ? Font.Bold : Font.Normal
+                    horizontalAlignment: isSmallLayout ? Qt.AlignHCenter : Qt.AlignLeft
+                    verticalAlignment: !heading.visible ? Qt.AlignVCenter : Qt.AlignTop
+                    wrapMode: Text.WordWrap
+                    elide: Text.ElideRight
+                    text: getConnectionStatusText()
+                }
+            }
+
+            MouseArea {
+                id: toggleArea
+                anchors.fill: parent
+                hoverEnabled: false
+                enabled: !root.editingLayout
+
+                onClicked: {
+                    // Toggle network on/off based on available device type
+                    if (wifiCheckVisible) {
+                        // Toggle WiFi
+                        network.handler.enableWireless(!network.enabledConnections.wirelessEnabled)
+                    } else if (airplaneCheckVisible) {
+                        // Toggle airplane mode
+                        PlasmaNM.Configuration.airplaneModeEnabled = !PlasmaNM.Configuration.airplaneModeEnabled
+                    } else if (wiredCheckVisible) {
+                        // Toggle wired/WWAN
+                        network.handler.enableWwan(!network.enabledConnections.wwanEnabled)
+                    }
+                }
             }
         }
 
+        // Divider
         Rectangle {
+            id: divider
             Layout.fillHeight: true
             Layout.preferredWidth: 1
             color: Kirigami.Theme.textColor
-            opacity: 0.2
-            visible: !longLayout.small
+            opacity: 0.3
+            visible: shouldShowExtendedUI
         }
 
+        // Right side (arrow/open settings) - just the icon
         Item {
+            id: rightButtonArea
             Layout.preferredWidth: networkBtn.height * 0.3
             Layout.fillHeight: true
-            visible: !longLayout.small
-
-            Rectangle {
-                anchors.fill: parent
-                color: Kirigami.Theme.highlightColor
-                opacity: arrowArea.containsMouse ? 0.2 : 0
-                radius: 4
-
-                Behavior on opacity {
-                    NumberAnimation { duration: 150 }
-                }
-            }
+            visible: shouldShowExtendedUI
 
             Kirigami.Icon {
                 anchors.centerIn: parent
@@ -147,24 +211,38 @@ Lib.Card {
                     fullRep.togglePage(fullRep.defaultInitialWidth, 400, networkPage)
                 }
             }
+
+            // Hover background
+            Rectangle {
+                anchors.fill: parent
+                color: Kirigami.Theme.highlightColor
+                opacity: arrowArea.containsMouse ? 0.2 : 0
+                radius: networkBtn.cornerRadius
+                z: -1
+
+                Behavior on opacity {
+                    NumberAnimation { duration: 150 }
+                }
+            }
         }
-    }
+        } // Close RowLayout
+    } // Close Rectangle
+
 
     // Short button layout (icon with circle background on top, text below, opens submenu)
     GridLayout {
         id: shortLayout
         anchors.fill: parent
-        property bool small: width < root.fullRepWidth/3
-        anchors.margins: shortLayout.small ? root.smallSpacing : root.largeSpacing
+        anchors.margins: isSmallLayout ? root.smallSpacing : root.largeSpacing
         rows: 2
-        columns: shortLayout.small ? 1 : 2
-        columnSpacing: shortLayout.small ? 0 : 10*root.scale
+        columns: isSmallLayout ? 1 : 2
+        columnSpacing: isSmallLayout ? 0 : 10*root.scale
         rowSpacing: 0
         visible: !isLongButton
 
         Item {
             id: iconShort
-            Layout.preferredHeight: shortLayout.small ? shortLayout.height/1.5 : shortLayout.height - root.largeSpacing
+            Layout.preferredHeight: isSmallLayout ? shortLayout.height/1.5 : shortLayout.height - root.largeSpacing
             Layout.preferredWidth: Layout.preferredHeight
             Layout.alignment: Qt.AlignVCenter | Qt.AlignHCenter
             Layout.rowSpan: 2
@@ -172,7 +250,7 @@ Lib.Card {
             Lib.Icon {
                 anchors.fill: parent
                 source: network.activeConnectionIcon
-                selected: (network.networkStatus.activeConnections != "") || isAirplane 
+                selected: (network.networkStatus.activeConnections != "") || isAirplane
             }
         }
 
@@ -180,56 +258,28 @@ Lib.Card {
             id: titleShort
             Layout.fillHeight: true
             Layout.fillWidth: true
-            Layout.margins: shortLayout.small ? root.smallSpacing : 1
+            Layout.margins: isSmallLayout ? root.smallSpacing : 1
             Layout.rowSpan: 2
-            font.pixelSize: shortLayout.small ? root.smallFontSize+0.5 : root.mediumFontSize
+            font.pixelSize: primaryFontSize
             font.weight: Font.Bold
-            horizontalAlignment: shortLayout.small ? Qt.AlignHCenter : Qt.AlignLeft
+            horizontalAlignment: isSmallLayout ? Qt.AlignHCenter : Qt.AlignLeft
             verticalAlignment: Qt.AlignVCenter
             wrapMode: Text.WordWrap
             elide: Text.ElideRight
             visible: text
-            text: network.networkStatus.activeConnections ? i18n("Connected") : isAirplane ? i18n("On") : i18n("Disconnected")
-        }
-    }
-
-    Rectangle {
-        anchors.fill: parent
-        color: Kirigami.Theme.highlightColor
-        opacity: (isWifi || isAirplane || isWired) ? 0.5 : (toggleArea.containsMouse ? 0.15 : 0)
-        radius: networkBtn.cornerRadius
-        z: -1
-        visible: isLongButton
-
-        Behavior on opacity {
-            NumberAnimation { duration: 150 }
+            text: getConnectionStatusText()
         }
     }
 
     MouseArea {
-        id: toggleArea
         anchors.fill: parent
-        anchors.rightMargin: (isLongButton && !longLayout.small) ? networkBtn.height * 0.3 + root.smallSpacing + 1 : 0
         hoverEnabled: true
         enabled: !root.editingLayout
+        visible: !isLongButton
 
         onClicked: {
-            if (isLongButton) {
-                // Long button: Toggle network on/off based on available device type
-                if (wifiCheckVisible) {
-                    // Toggle WiFi
-                    network.handler.enableWireless(!network.enabledConnections.wirelessEnabled)
-                } else if (airplaneCheckVisible) {
-                    // Toggle airplane mode
-                    PlasmaNM.Configuration.airplaneModeEnabled = !PlasmaNM.Configuration.airplaneModeEnabled
-                } else if (wiredCheckVisible) {
-                    // Toggle wired/WWAN
-                    network.handler.enableWwan(!network.enabledConnections.wwanEnabled)
-                }
-            } else {
-                // Short button: Open network page
-                fullRep.togglePage(fullRep.defaultInitialWidth, 400, networkPage)
-            }
+            // Short button: Open network page
+            fullRep.togglePage(fullRep.defaultInitialWidth, 400, networkPage)
         }
     }
 }


### PR DESCRIPTION
The modification would make the Wifi Button look like Gnome. Here is a screenshot along with the unmodified bluetooth button:

<img width="337" height="303" alt="image" src="https://github.com/user-attachments/assets/e64692f4-248e-4338-9b75-e256e4df446b" />

When the button is pressed it would activate/deactivate the wifi, when the arrow is pressed it would show the list previously shown.

I know this is not the proper way to make the modification but I only consider this as a proof-of-concept.