### PR TITLE
fix: network icon stays highlighted when Wi-Fi is off

### DIFF
--- a/package/contents/ui/components/NetworkBtn.qml
+++ b/package/contents/ui/components/NetworkBtn.qml
@@ -58,7 +58,7 @@ Lib.CardButton {
     Lib.Icon {
         anchors.fill: parent
         source: network.activeConnectionIcon
-        selected: (network.networkStatus.activeConnections != "") || isAirplane 
+        selected: isWifi || isAirplane || isWired
         enableQuickAction: root.enableQuickActions
 
         onQuickActionTriggered: {


### PR DESCRIPTION
## Problem

When Wi-Fi is disabled, the network icon remained highlighted (blue) 
instead of turning grey. This happened because the `selected` property 
was based on `activeConnections` string, which returns `lo` (loopback 
interface) even when no real network is active — causing the condition 
to always evaluate as `true`.

## Root Cause

In `NetworkBtn.qml`:
```qml
// Before: always true because activeConnections returns "lo"
selected: (network.networkStatus.activeConnections != "") || isAirplane
```

## Fix

Use the existing boolean properties `isWifi`, `isWired`, `isAirplane` 
which correctly reflect the actual network state:

```qml
// After: correctly reflects real network state
selected: isWifi || isAirplane || isWired
```

## Screenshots

### Before
| Off | Disconnected | Connected |
|---|---|---|
| <img width="1920" height="1033" alt="image" src="https://github.com/user-attachments/assets/baf5a113-9ecd-457d-aca1-29f1a719161e" /> | <img width="1920" height="1033" alt="image" src="https://github.com/user-attachments/assets/40d5bb7b-fd2f-43f4-920c-679be46f617f" /> | <img width="1920" height="1033" alt="image" src="https://github.com/user-attachments/assets/e4de44c6-af1a-447b-ac21-9f163b04b895" /> |

### After
| Off | Disconnected | Connected |
|---|---|---|
| <img width="1920" height="1033" alt="image" src="https://github.com/user-attachments/assets/132d12e8-6fea-410b-940f-b56adffd86f5" /> | <img width="1920" height="1033" alt="image" src="https://github.com/user-attachments/assets/a3d7abb4-f70d-4ad2-9f1e-a1d5c874bde4" /> | <img width="1920" height="1033" alt="image" src="https://github.com/user-attachments/assets/5eceb5ef-f90d-42ef-b5d6-a4a70d6c3fa9" /> |