### PR TITLE
Added a forget device button right in the bluetooth menu

### DIFF
--- a/package/contents/ui/pages/BluetoothPage.qml
+++ b/package/contents/ui/pages/BluetoothPage.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import QtQuick.Controls as QQC2
 
+import org.kde.bluedevil.components as BluedevilComponents
 import org.kde.bluezqt as BluezQt
 import org.kde.kirigami as Kirigami
 import org.kde.ksvg as KSvg
@@ -66,6 +67,16 @@ PageTemplate {
 
     BluetoothComponents.Header {
         id: header
+    }
+
+    readonly property alias forgetDialog: forgetDialogInstance
+
+    BluedevilComponents.ForgetDeviceDialog {
+        id: forgetDialogInstance
+        parent: bluetoothPage
+        registerCallForDeviceUbi: (call, ubi) => {
+            PlasmaBt.SharedDevicesStateProxyModel.registerDisconnectingCallForDeviceUbi(call, ubi);
+        }
     }
 
     QQC2.Action {
@@ -141,7 +152,9 @@ PageTemplate {
             highlight: PlasmaExtras.Highlight {}
             highlightMoveDuration: Kirigami.Units.shortDuration
             highlightResizeDuration: Kirigami.Units.shortDuration
-            delegate: BluetoothComponents.DeviceItem {}
+            delegate: BluetoothComponents.DeviceItem {
+                forgetDeviceDialog: bluetoothPage.forgetDialog
+            }
 
             Keys.onUpPressed: event => {
                 if (listView.currentIndex === 0) {

--- a/package/contents/ui/pages/components/bluetooth/DeviceItem.qml
+++ b/package/contents/ui/pages/components/bluetooth/DeviceItem.qml
@@ -25,6 +25,8 @@ PlasmaExtras.ExpandableListItem {
     required property int index
     required property var model
 
+    required property var forgetDeviceDialog
+
     property list<string> currentDeviceDetails
 
     icon: model.Icon
@@ -60,6 +62,16 @@ PlasmaExtras.ExpandableListItem {
 
             onTriggered: source => {
                 PlasmaBt.LaunchApp.launchSendFile(root.model.Ubi);
+            }
+        },
+        QQC2.Action {
+            id: forgetDeviceAction
+            enabled: root.model.Paired
+            icon.name: "edit-delete-remove-symbolic"
+            text: i18nc("@action:button Forget a Bluetooth device", "Forget")
+
+            onTriggered: source => {
+                root.forgetDeviceDialog.open(root.model.Device);
             }
         }
     ]


### PR DESCRIPTION
This is so you dont have to go to settings to forget a device. This also is more like how the Default KDE bluetooth widget is.

Uses the stock org.kde.bluedevil.components.ForgetDeviceDialog so the confirmation prompt matches the system Bluetooth applet's, with one shared dialog instance at the page level passed into each delegate. Shows the dialog within the control center, not in the center of the screen.

To test:
- Open Control Center and go to Bluetooth. Connect a device, and see that there is now a forget button. Toggling that button will dim the screen and show a dialog with two options. Clicking forget will remove the device from the Bluetooth menu and globally. Browse Files / Send File actions unaffected. Connect/Disconnect button (default action) still works