### PR TITLE
fix(NetworkBtn): correct icon selected state using real connectivity

### DIFF
--- a/package/contents/ui/components/NetworkBtn.qml
+++ b/package/contents/ui/components/NetworkBtn.qml
@@ -5,6 +5,7 @@ import QtQuick.Layouts 1.15
 import org.kde.plasma.core as PlasmaCore
 
 import org.kde.plasma.networkmanagement as PlasmaNM
+import org.kde.networkmanager as NMQt
 import org.kde.kirigami as Kirigami
 
 
@@ -23,23 +24,19 @@ Lib.CardButton {
                 && network.availableDevices.wirelessDeviceAvailable
                 && network.enabledConnections.wirelessHwEnabled
 
-    readonly property bool administrativelyWiredEnabled:
-                !PlasmaNM.Configuration.airplaneModeEnabled
-                && network.availableDevices.modemDeviceAvailable
-                && network.enabledConnections.wwanHwEnabled
-
     readonly property bool wifiCheckChecked: administrativelyEnabled && network.enabledConnections.wirelessEnabled
     readonly property bool wifiCheckVisible: network.availableDevices.wirelessDeviceAvailable
 
     readonly property bool airplaneCheckchecked: PlasmaNM.Configuration.airplaneModeEnabled
     readonly property bool airplaneCheckVisible: network.availableDevices.modemDeviceAvailable || network.availableDevices.wirelessDeviceAvailable
 
-    readonly property bool wiredCheckchecked: administrativelyWiredEnabled && network.enabledConnections.wwanEnabled
-    readonly property bool wiredCheckVisible: network.availableDevices.modemDeviceAvailable
-
     readonly property var isWifi: wifiCheckChecked && wifiCheckVisible
     readonly property var isAirplane: airplaneCheckchecked && airplaneCheckVisible
-    readonly property var isWired: wiredCheckchecked && wiredCheckVisible
+    
+    readonly property bool isConnected: {
+        const c = network.networkStatus.connectivity;
+        return c === NMQt.NetworkManager.Full || c === NMQt.NetworkManager.Limited || c === NMQt.NetworkManager.Portal;
+    }
 
     Network {
         id: network
@@ -58,7 +55,7 @@ Lib.CardButton {
     Lib.Icon {
         anchors.fill: parent
         source: network.activeConnectionIcon
-        selected: (network.networkStatus.activeConnections != "") || isAirplane 
+        selected: isWifi || isAirplane || isConnected
         enableQuickAction: root.enableQuickActions
 
         onQuickActionTriggered: {


### PR DESCRIPTION
## What was broken?
Network button stayed highlighted even if wifi and airplane mode was off and there was no wired connection either. So basically **it was always highlighted** and **never greyed out** as it should in case everything was off.

## Why it was broken?
The `selected` state came from `network.networkStatus.activeConnections != ""`, but that property returns a NetworkManager status string which probably is never empty string  even if there's no active connection. so check was almost always true and the network icon stayed highlighted even with wifi off, no wired connection and airplane mode disabled.
## How it fixes this issue?
Replacing it with `networkStatus.connectivity`, which reflects actual NetworkManager connectivity state (Full/Limited/Portal/None) and updates reactively via its NOTIFY signal. This is actually the same approach used by KDE's own Networks applet.

*And yes i have checked it with wired connection too it stays highlighted in case of wired connection unlike one of the pull requests i saw was just using your previously defined `isWired` which actually was not the correct way to detect wired connections :)*

## After change
selected is now true when:
- Wi-Fi button is enabled (isWifi), even if not connected to any network
- Airplane mode is on (isAirplane)
- The system has real connectivity (isConnected)

### Before and after:
<img width="221" alt="Screenshot_20260802_181341" src="https://github.com/user-attachments/assets/f76ff50e-2957-4569-b421-12185db9c4ef" /> <img width="200" alt="Screenshot_20260802_181745" src="https://github.com/user-attachments/assets/61a623bb-fd38-4341-9435-c001f2e781f6" />
